### PR TITLE
Refactor docstrings to Google style format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,22 +29,17 @@ Dagster Web UIを見るだけで、アセットの内容や処理フローが直
    # ✅ 新: fetch_raw_pages, validate_pages, clean_and_process_pages, store_pages_to_csv
    ```
 
-2. **包括的なdocstring（1行要約 + 詳細 + 入出力仕様）**
+2. **Google style docstring（処理内容含む1行目 + Args/Returns）**
    ```python
    @asset(description="Wikipedia APIからページ一覧（pageid, title）を取得する")
    def fetch_raw_pages(context: AssetExecutionContext) -> pd.DataFrame:
-       """
-       Wikipedia APIからページ一覧を取得し、生データのDataFrameを返す。
+       """Wikipedia APIからページ一覧を取得し、環境変数設定とAPI呼び出しを実行する。
        
-       処理内容:
-         1. 環境変数からAPI URLを取得
-         2. WikipediaApiConfigでリクエスト設定
-         3. allpages APIエンドポイントを呼び出し
-         4. JSONレスポンスをDataFrameに変換
-       
-       出力:
-         - pageid(int): Wikipedia固有のページID
-         - title(str): ページタイトル
+       Args:
+           context: Dagsterアセット実行コンテキスト
+           
+       Returns:
+           pd.DataFrame: pageidとtitleカラムを含む生データのDataFrame
        """
    ```
 
@@ -73,13 +68,14 @@ Dagster Web UIを見るだけで、アセットの内容や処理フローが直
 ```markdown
 以下の仕様で asset を追加して：
 - validate_pages の後に、title に "List of" を含むページだけを抽出する filter_pages_by_list アセットを追加
-- 「UIだけ見れば8割わかる Dagster 資産」ベストプラクティスを適用（動詞命名、包括的docstring、動的メタデータ、構造化ログ）
+- 「UIだけ見れば8割わかる Dagster 資産」ベストプラクティスを適用（動詞命名、Google style docstring、動的メタデータ、構造化ログ）
 - 新たなジョブ filter_job を作成
 ```
 
 ```markdown
 domain/models.py の PageSchema に namespace カラム（str型）を追加し、関連コードも更新して
 既存アセットも「UIだけ見れば8割わかる」パターンに合わせて更新
+docstringはGoogle style（処理内容含む1行目 + Args/Returns）で記述
 ```
 
 ---
@@ -202,7 +198,7 @@ docker-compose up --build
 
 ### 🎨 「UIだけ見れば8割わかる」パターン
 * **動詞命名**: `fetch_`, `validate_`, `clean_`, `store_`, `filter_`
-* **包括的docstring**: 1行要約 + 処理内容 + 入出力仕様
+* **Google style docstring**: 処理内容含む1行目 + Args/Returns（日本語）
 * **動的メタデータ**: row_count, preview, output_path 等
 * **構造化ログ**: `{asset_name}: 開始/完了 {key=value}`
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker-compose up -d dagster-web
 
 1. **アセットの実行**
    - 「Assets」タブでアセット一覧を確認
-   - 実行したいアセット（例: `exported_csv`）をクリック
+   - 実行したいアセット（例: `store_pages_to_csv`）をクリック
    - 「Materialize」→「Materialize with upstream」で依存関係含めて実行
 
 2. **ジョブの実行**
@@ -174,13 +174,20 @@ docker-compose run --rm dagster-test uv run pytest --cov=domain --cov=infrastruc
 
 ## 📊 アセット構成
 
-### データフロー
-1. `raw_wikipedia_pages` - Wikipedia APIからの生データ取得
-2. `validated_pages` - Panderaによるデータバリデーション
-3. `processed_pages` - データクリーニングと前処理
-4. `exported_csv` - CSV形式でのエクスポート
-5. `filtered_pages` - 条件による絞り込み処理
-6. `filtered_csv_export` - フィルタ済みデータのエクスポート
+### データフロー（「UIだけ見れば8割わかる Dagster 資産」適用済み）
+1. `fetch_raw_pages` - Wikipedia APIからページ一覧を取得し、環境変数設定とAPI呼び出しを実行
+2. `validate_pages` - Panderaでスキーマ検証を実行し、型変換と必須フィールドチェックを行う
+3. `clean_and_process_pages` - テキストクリーニング、重複除去、メタデータ付与を実行
+4. `store_pages_to_csv` - 処理済みデータを環境変数で指定されたパスにCSVファイルとして出力
+5. `filter_pages_by_criteria` - タイトル条件でページをフィルタリングし、フォールバック機能で必ずデータを返す
+6. `store_filtered_pages_to_csv` - フィルタリング済みデータを空チェックしてCSVファイルに出力
+
+### ベストプラクティス適用内容
+- **動詞ベースの命名**: `fetch_`, `validate_`, `clean_`, `store_`, `filter_` パターン
+- **Google style docstring**: 処理内容を含む1行目 + Args/Returns（日本語）
+- **動的メタデータ**: UI表示用の`row_count`, `preview`, `output_path`等
+- **構造化ログ**: `{asset_name}: 開始/完了 {key=value}` パターン
+- **明確な依存関係**: アセット間の依存関係とフォールバック機能
 
 ## 🔧 設定とカスタマイズ
 


### PR DESCRIPTION
## Summary

全アセットのdocstringをGoogle style形式に統一し、日本語コメントで分かりやすく記述しました。

### 主な変更点

#### **docstring形式の統一**
- **Google style形式**に変更（Args/Returns構造）
- **処理内容を含む1行目**で何をするかを明確に記述
- **日本語でのコメント**で可読性を向上
- **Args**: 引数の説明を日本語で記述
- **Returns**: 戻り値の説明を日本語で記述
- **Raises**: 例外の説明（該当する場合）

#### **修正したアセット**
- `fetch_raw_pages` - Wikipedia API呼び出し処理
- `validate_pages` - Panderaスキーマ検証処理  
- `clean_and_process_pages` - データクリーニング処理
- `store_pages_to_csv` - CSV出力処理
- `filter_pages_by_criteria` - フィルタリング処理
- `store_filtered_pages_to_csv` - フィルタ済みCSV出力処理

#### **ドキュメント更新**
- **README.md**: アセット名と説明を新しい命名規則に更新
- **CLAUDE.md**: docstring例とベストプラクティス説明を修正

### docstring例

```python
def fetch_raw_pages(context: AssetExecutionContext) -> pd.DataFrame:
    """Wikipedia APIからページ一覧を取得し、環境変数設定とAPI呼び出しを実行する。
    
    Args:
        context: Dagsterアセット実行コンテキスト
        
    Returns:
        pd.DataFrame: pageidとtitleカラムを含む生データのDataFrame
    """
```

### 効果

1. **コードの可読性向上**: 標準的なGoogle style形式で統一
2. **日本語での説明**: 処理内容が直感的に理解可能
3. **メンテナンス性向上**: 一貫したdocstring形式
4. **新規開発時の指針**: 今後のアセット追加時の参考

入出力の詳細情報は既存の**動的メタデータ**でDagster UIに表示されるため、docstringはシンプルかつ分かりやすい構造になっています。

🤖 Generated with [Claude Code](https://claude.ai/code)